### PR TITLE
Upgrade to draft version 07

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 # SD-JWT Reference implementation
 
-Rust implementation of the [Selective Disclosure for JWTs (SD-JWT) **version 06**](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-06.html)
+Rust implementation of the [Selective Disclosure for JWTs (SD-JWT) **version 07**](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html)
 
 ## Overview
 

--- a/src/disclosure.rs
+++ b/src/disclosure.rs
@@ -10,7 +10,7 @@ use std::fmt::Display;
 /// Represents an elements constructing a disclosure.
 /// Object properties and array elements disclosures are supported.
 ///
-/// See: https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-06.html#name-disclosures
+/// See: https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#name-disclosures
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Disclosure {
   /// The salt value.
@@ -140,7 +140,7 @@ mod test {
   use super::Disclosure;
 
   // Test values from:
-  // https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-05.html#appendix-A.2-7
+  // https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#appendix-A.2-7
   #[test]
   fn test_parsing() {
     let disclosure = Disclosure::new(

--- a/src/disclosure.rs
+++ b/src/disclosure.rs
@@ -68,8 +68,7 @@ impl Disclosure {
 
     if decoded.len() == 2 {
       Ok(Self {
-        salt: decoded
-          .get(0)
+        salt: decoded.first()
           .ok_or(Error::InvalidDisclosure("invalid salt".to_string()))?
           .as_str()
           .ok_or(Error::InvalidDisclosure(
@@ -86,8 +85,7 @@ impl Disclosure {
       })
     } else if decoded.len() == 3 {
       Ok(Self {
-        salt: decoded
-          .get(0)
+        salt: decoded.first()
           .ok_or(Error::InvalidDisclosure("invalid salt".to_string()))?
           .as_str()
           .ok_or(Error::InvalidDisclosure(

--- a/src/disclosure.rs
+++ b/src/disclosure.rs
@@ -68,7 +68,8 @@ impl Disclosure {
 
     if decoded.len() == 2 {
       Ok(Self {
-        salt: decoded.first()
+        salt: decoded
+          .first()
           .ok_or(Error::InvalidDisclosure("invalid salt".to_string()))?
           .as_str()
           .ok_or(Error::InvalidDisclosure(
@@ -85,7 +86,8 @@ impl Disclosure {
       })
     } else if decoded.len() == 3 {
       Ok(Self {
-        salt: decoded.first()
+        salt: decoded
+          .first()
           .ok_or(Error::InvalidDisclosure("invalid salt".to_string()))?
           .as_str()
           .ok_or(Error::InvalidDisclosure(

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,4 +39,7 @@ pub enum Error {
 
   #[error("salt size must be greater than or equal to 16")]
   InvalidSaltSize,
+
+  #[error("the validation ended with {0} unused disclosure(s)")]
+  UnusedDisclosures(usize),
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -15,7 +15,7 @@ pub const SHA_ALG_NAME: &str = "sha-256";
 ///
 /// Implementations of this trait are expected only for algorithms listed in
 /// the IANA "Named Information Hash Algorithm" registry.
-/// See [Hash Function Claim](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-06.html#name-hash-function-claim)
+/// See [Hash Function Claim](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#name-hash-function-claim)
 pub trait Hasher: Sync + Send {
   /// Digests input to produce unique fixed-size hash value in bytes.
   fn digest(&self, input: &[u8]) -> Vec<u8>;
@@ -60,7 +60,7 @@ impl Hasher for Sha256Hasher {
   }
 }
 
-// Some test values taken from https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-05.html#name-hashing-disclosures
+// Some test values taken from https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#name-disclosures
 #[cfg(test)]
 mod test {
   use crate::Hasher;

--- a/src/key_binding_jwt_claims.rs
+++ b/src/key_binding_jwt_claims.rs
@@ -11,13 +11,12 @@ use crate::Hasher;
 use serde::Deserialize;
 use serde::Serialize;
 
-///
+/// Claims set for key binding JWT.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct KeyBindingJwtClaims {
   pub iat: i64,
   pub aud: String,
   pub nonce: String,
-  #[serde(rename = "_sd_hash")]
   pub sd_hash: String,
   #[serde(flatten)]
   pub properties: BTreeMap<String, Value>,
@@ -27,7 +26,7 @@ impl KeyBindingJwtClaims {
   pub const KB_JWT_HEADER_TYP: &'static str = " kb+jwt";
 
   /// Creates a new [`KeyBindingJwtClaims`].
-  /// When `issued_at` is left as None, it will automatically default to the current time
+  /// When `issued_at` is left as None, it will automatically default to the current time.
   ///
   /// # Panic
   /// When `issued_at` is set to `None` and the system returns time earlier than `SystemTime::UNIX_EPOCH`.

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -18,7 +18,7 @@ use sd_jwt_payload::SdObjectEncoder;
 
 #[test]
 fn test_complex_structure() {
-  // Values taken from https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-06.html#appendix-A.2
+  // Values taken from https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#appendix-A.2
   let object = json!({
     "verified_claims": {
       "verification": {


### PR DESCRIPTION
* Changes the claim name from _sd_hash to sd_hash.
* Checks that no unused disclosures remain at the end of verifying.
* Fixes verifying duplicate digests.

https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#appendix-C-2