### PR TITLE
Use JSON Pointer for `conceal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+## [0.2.0]
+
+### Added
+- `HEADER_TYP` constant.
+
+### Changed
+- Changed `SdObjectEncoder::conceal` to take a JSON pointer string, instead of a string array.
+
+### Removed
+- Removed `SdObjectEncoder::conceal_array_entry` (replaced by `SdObjectEncoder::conceal`).
+
+### Fixed
+- Decoding bug when objects inside arrays include digests and plain text values.
+
+## [0.1.2]
+- 07 Draft implementation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ strum = { version = "0.25", default-features = false, features = ["std", "derive
 itertools = { version = "0.12", default-features = false, features = ["use_std"]  }
 iota-crypto = { version = "0.23", default-features = false, features = ["sha"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+json-pointer = "0.3.4"
 
 [dev-dependencies]
 josekit = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sd-jwt-payload"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["IOTA Stiftung"]
 homepage = "https://www.iota.org"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ multibase = { version = "0.9", default-features = false, features = ["std"] }
 serde_json = { version = "1.0", default-features = false, features = ["std" ] }
 rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"] }
 thiserror = { version = "1.0", default-features = false }
-strum = { version = "0.25", default-features = false, features = ["std", "derive"] }
+strum = { version = "0.26", default-features = false, features = ["std", "derive"] }
 itertools = { version = "0.12", default-features = false, features = ["use_std"]  }
 iota-crypto = { version = "0.23", default-features = false, features = ["sha"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/examples/sd_jwt.rs
+++ b/examples/sd_jwt.rs
@@ -37,11 +37,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
   let mut encoder: SdObjectEncoder = object.try_into()?;
   let disclosures: Vec<Disclosure> = vec![
-    encoder.conceal(&["email"], None)?,
-    encoder.conceal(&["phone_number"], None)?,
-    encoder.conceal(&["address", "street_address"], None)?,
-    encoder.conceal(&["address"], None)?,
-    encoder.conceal_array_entry(&["nationalities"], 0, None)?,
+    encoder.conceal("/email", None)?,
+    encoder.conceal("phone_number", None)?,
+    encoder.conceal("address/street_address", None)?,
+    encoder.conceal("address", None)?,
+    encoder.conceal(&"nationalities/0", None)?,
   ];
   encoder.add_sd_alg_property();
 
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn Error>> {
   header.set_token_type("sd-jwt");
 
   // Use the encoded object as a payload for the JWT.
-  let payload = JwtPayload::from_map(encoder.object().clone())?;
+  let payload = JwtPayload::from_map(encoder.object().as_object().unwrap().clone())?;
   let key = b"0123456789ABCDEF0123456789ABCDEF";
   let signer = HS256.signer_from_bytes(key)?;
   let jwt = jwt::encode_with_signer(&payload, &header, &signer)?;

--- a/examples/sd_jwt.rs
+++ b/examples/sd_jwt.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 IOTA Stiftung
+// Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::error::Error;
@@ -11,6 +11,7 @@ use sd_jwt_payload::Disclosure;
 use sd_jwt_payload::SdJwt;
 use sd_jwt_payload::SdObjectDecoder;
 use sd_jwt_payload::SdObjectEncoder;
+use sd_jwt_payload::HEADER_TYP;
 use serde_json::json;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -38,22 +39,26 @@ fn main() -> Result<(), Box<dyn Error>> {
   let mut encoder: SdObjectEncoder = object.try_into()?;
   let disclosures: Vec<Disclosure> = vec![
     encoder.conceal("/email", None)?,
-    encoder.conceal("phone_number", None)?,
-    encoder.conceal("address/street_address", None)?,
-    encoder.conceal("address", None)?,
-    encoder.conceal(&"nationalities/0", None)?,
+    encoder.conceal("/phone_number", None)?,
+    encoder.conceal("/address/street_address", None)?,
+    encoder.conceal("/address", None)?,
+    encoder.conceal("/nationalities/0", None)?,
   ];
+
+  encoder.add_decoys("/nationalities", 3)?;
+  encoder.add_decoys("", 4)?; // Add decoys to the top level.
+
   encoder.add_sd_alg_property();
 
-  println!("encoded object: {}", serde_json::to_string_pretty(encoder.object())?);
+  println!("encoded object: {}", serde_json::to_string_pretty(encoder.object()?)?);
 
   // Create the JWT.
   // Creating JWTs is outside the scope of this library, josekit is used here as an example.
   let mut header = JwsHeader::new();
-  header.set_token_type("sd-jwt");
+  header.set_token_type(HEADER_TYP);
 
   // Use the encoded object as a payload for the JWT.
-  let payload = JwtPayload::from_map(encoder.object().as_object().unwrap().clone())?;
+  let payload = JwtPayload::from_map(encoder.object()?.clone())?;
   let key = b"0123456789ABCDEF0123456789ABCDEF";
   let signer = HS256.signer_from_bytes(key)?;
   let jwt = jwt::encode_with_signer(&payload, &header, &signer)?;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -265,12 +265,16 @@ mod test {
       "id": "did:value",
     });
     let mut encoder = SdObjectEncoder::try_from(object).unwrap();
-    let dis = encoder.conceal(&["id"], None).unwrap();
+    let dis = encoder.conceal("/id", None).unwrap();
     encoder
-      .object_mut()
+      .object
+      .as_object_mut()
+      .unwrap()
       .insert("id".to_string(), Value::String("id-value".to_string()));
     let decoder = SdObjectDecoder::new_with_sha256();
-    let decoded = decoder.decode(encoder.object(), &vec![dis.to_string()]).unwrap_err();
+    let decoded = decoder
+      .decode(encoder.object().as_object().unwrap(), &vec![dis.to_string()])
+      .unwrap_err();
     assert!(matches!(decoded, Error::ClaimCollisionError(_)));
   }
 
@@ -286,7 +290,7 @@ mod test {
     encoder.add_sd_alg_property();
     assert_eq!(encoder.object().get("_sd_alg").unwrap(), "sha-256");
     let decoder = SdObjectDecoder::new_with_sha256();
-    let decoded = decoder.decode(encoder.object(), &vec![]).unwrap();
+    let decoded = decoder.decode(encoder.object().as_object().unwrap(), &vec![]).unwrap();
     assert!(decoded.get("_sd_alg").is_none());
   }
 
@@ -296,7 +300,7 @@ mod test {
       "id": "did:value",
     });
     let mut encoder = SdObjectEncoder::try_from(object).unwrap();
-    let dislosure: Disclosure = encoder.conceal(&["id"], Some("test".to_string())).unwrap();
+    let dislosure: Disclosure = encoder.conceal("/id", Some("test".to_string())).unwrap();
     // 'obj' contains digest of `id` twice.
     let obj = json!({
       "_sd":[
@@ -317,8 +321,8 @@ mod test {
       "tst": "tst-value"
     });
     let mut encoder = SdObjectEncoder::try_from(object).unwrap();
-    let disclosure_1: Disclosure = encoder.conceal(&["id"], Some("test".to_string())).unwrap();
-    let disclosure_2: Disclosure = encoder.conceal(&["tst"], Some("test".to_string())).unwrap();
+    let disclosure_1: Disclosure = encoder.conceal("/id", Some("test".to_string())).unwrap();
+    let disclosure_2: Disclosure = encoder.conceal("/tst", Some("test".to_string())).unwrap();
     // 'obj' contains only the digest of `id`.
     let obj = json!({
       "_sd":[

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 IOTA Stiftung
+// Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ARRAY_DIGEST_KEY;
@@ -15,7 +15,7 @@ use serde_json::Map;
 use serde_json::Value;
 use std::collections::BTreeMap;
 
-/// Substitutes digests in an SD-JWT object by their corresponding plaintext values provided by disclosures.
+/// Substitutes digests in an SD-JWT object by their corresponding plain text values provided by disclosures.
 pub struct SdObjectDecoder {
   hashers: BTreeMap<String, Box<dyn Hasher>>,
 }
@@ -54,7 +54,7 @@ impl SdObjectDecoder {
   }
 
   /// Decodes an SD-JWT `object` containing by Substituting the digests with their corresponding
-  /// plaintext values provided by `disclosures`.
+  /// plain text values provided by `disclosures`.
   ///
   /// ## Notes
   /// * The hasher is determined by the `_sd_alg` property. If none is set, the sha-256 hasher will
@@ -204,7 +204,7 @@ impl SdObjectDecoder {
 
             // Reject if any digests were found more than once.
             if processed_digests.contains(&digest_in_array) {
-              return Err(Error::DuplicateDigestError(digest_in_array));
+              // return Err(Error::DuplicateDigestError(digest_in_array));
             }
             if let Some(disclosure) = disclosures.get(&digest_in_array) {
               if disclosure.claim_name.is_some() {
@@ -227,6 +227,7 @@ impl SdObjectDecoder {
           } else {
             let decoded_object = self.decode_object(object, disclosures, processed_digests)?;
             output.push(Value::Object(decoded_object));
+            break;
           }
         }
       } else if let Some(arr) = value.as_array() {
@@ -273,7 +274,7 @@ mod test {
       .insert("id".to_string(), Value::String("id-value".to_string()));
     let decoder = SdObjectDecoder::new_with_sha256();
     let decoded = decoder
-      .decode(encoder.object().as_object().unwrap(), &vec![dis.to_string()])
+      .decode(encoder.object().unwrap(), &vec![dis.to_string()])
       .unwrap_err();
     assert!(matches!(decoded, Error::ClaimCollisionError(_)));
   }
@@ -288,9 +289,9 @@ mod test {
     });
     let mut encoder = SdObjectEncoder::try_from(object).unwrap();
     encoder.add_sd_alg_property();
-    assert_eq!(encoder.object().get("_sd_alg").unwrap(), "sha-256");
+    assert_eq!(encoder.object().unwrap().get("_sd_alg").unwrap(), "sha-256");
     let decoder = SdObjectDecoder::new_with_sha256();
-    let decoded = decoder.decode(encoder.object().as_object().unwrap(), &vec![]).unwrap();
+    let decoded = decoder.decode(encoder.object().unwrap(), &vec![]).unwrap();
     assert!(decoded.get("_sd_alg").is_none());
   }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -204,7 +204,7 @@ impl SdObjectDecoder {
 
             // Reject if any digests were found more than once.
             if processed_digests.contains(&digest_in_array) {
-              // return Err(Error::DuplicateDigestError(digest_in_array));
+              return Err(Error::DuplicateDigestError(digest_in_array));
             }
             if let Some(disclosure) = disclosures.get(&digest_in_array) {
               if disclosure.claim_name.is_some() {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 IOTA Stiftung
+// Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Disclosure;
@@ -7,6 +7,7 @@ use super::Hasher;
 use super::Sha256Hasher;
 use crate::Error;
 use crate::Result;
+use json_pointer::JsonPointer;
 use rand::Rng;
 use serde_json::json;
 use serde_json::Map;
@@ -22,12 +23,12 @@ pub(crate) const SD_ALG: &str = "_sd_alg";
 #[cfg(not(feature = "sha"))]
 pub struct SdObjectEncoder<H: Hasher> {
   /// The object in JSON format.
-  object: Map<String, Value>,
+  pub(crate) object: Value,
   /// Size of random data used to generate the salts for disclosures in bytes.
   /// Constant length for readability considerations.
-  salt_size: usize,
+  pub(crate) salt_size: usize,
   /// The hash function used to create digests.
-  hasher: H,
+  pub(crate) hasher: H,
 }
 
 /// Transforms a JSON object into an SD-JWT object by substituting selected values
@@ -36,12 +37,12 @@ pub struct SdObjectEncoder<H: Hasher> {
 #[derive(Debug, Clone)]
 pub struct SdObjectEncoder<H: Hasher = Sha256Hasher> {
   /// The object in JSON format.
-  object: Map<String, Value>,
+  pub(crate) object: Value,
   /// Size of random data used to generate the salts for disclosures in bytes.
   /// Constant length for readability considerations.
-  salt_size: usize,
+  pub(crate) salt_size: usize,
   /// The hash function used to create digests.
-  hasher: H,
+  pub(crate) hasher: H,
 }
 
 #[cfg(feature = "sha")]
@@ -73,11 +74,11 @@ impl TryFrom<Value> for SdObjectEncoder {
   type Error = crate::Error;
 
   fn try_from(value: Value) -> std::result::Result<Self, Self::Error> {
-    match value {
-      Value::Object(object) => Ok(SdObjectEncoder {
-        object,
+    match value.clone() {
+      Value::Object(_) => Ok(SdObjectEncoder {
         salt_size: DEFAULT_SALT_SIZE,
         hasher: Sha256Hasher::new(),
+        object: value,
       }),
       _ => Err(Error::DataTypeMismatch("expected object".to_owned())),
     }
@@ -94,124 +95,70 @@ impl<H: Hasher> SdObjectEncoder<H> {
     })
   }
 
-  /// Substitutes a value with the digest of its disclosure.
-  /// If no salt is provided, the disclosure will be created with a random salt value.
-  ///
-  /// The value of the key specified in `path` will be concealed. E.g. for path
-  /// `["claim", "subclaim"]` the value of `claim.subclaim` will be concealed.
-  ///
-  /// ## Error
-  /// [`Error::InvalidPath`] if path is invalid or the path slice is empty.
-  /// [`Error::DataTypeMismatch`] if existing SD format is invalid.
-  ///
-  /// ## Note
-  /// Use `conceal_array_entry` for values in arrays.
-  pub fn conceal(&mut self, path: &[&str], salt: Option<String>) -> Result<Disclosure> {
-    // Error if path is not provided.
-    if path.is_empty() {
-      return Err(Error::InvalidPath("the provided path length is 0".to_string()));
-    }
-
+  pub fn conceal(&mut self, pointer: &str, salt: Option<String>) -> Result<Disclosure> {
     // Determine salt.
     let salt = salt.unwrap_or(Self::gen_rand(self.salt_size));
 
-    // Obtain the parent of the property specified by the provided path.
-    let (target_key, parent_value) = Self::get_target_property_and_its_parent(&mut self.object, path)?;
+    let element_pointer = pointer
+      .parse::<JsonPointer<_, _>>()
+      .map_err(|err| Error::InvalidPath(format!("{:?}", err)))?;
 
-    // Remove the value from the parent and create a disclosure for it.
-    let disclosure = Disclosure::new(
-      salt,
-      Some(target_key.to_owned()),
-      parent_value
-        .remove(target_key)
-        .ok_or(Error::InvalidPath(format!("{} does not exist", target_key)))?,
-    );
+    let mut parent_pointer = element_pointer.clone();
+    let element_key = parent_pointer
+      .pop()
+      .ok_or(Error::InvalidPath("path does not contain any values".to_string()))?;
 
-    // Hash the disclosure.
-    let hash = self.hasher.encoded_digest(disclosure.as_str());
+    let parent = parent_pointer
+      .get(&self.object)
+      // .map_err(|err| Error::InvalidPath("specified path does not match a json value".to_string()))?;
+      .map_err(|err| Error::InvalidPath(format!("{:?}", err)))?;
 
-    // Add the hash to the "_sd" array if exists; otherwise, create the array and insert the hash.
-    Self::add_digest_to_object(parent_value, hash)?;
-    Ok(disclosure)
-  }
+    match parent {
+      Value::Object(_) => {
+        let parent = parent_pointer
+          .get_mut(&mut self.object)
+          .map_err(|err| Error::InvalidPath(format!("{:?}", err)))?
+          .as_object_mut()
+          .ok_or(Error::InvalidPath("path does not contain any values".to_string()))?;
 
-  /// Substitutes a value within an array with the digest of its disclosure.
-  /// If no salt is provided, the disclosure will be created with random salt value.
-  ///
-  /// `path` is used to specify the array in the object, while `element_index` specifies
-  /// the index of the element to be concealed (index start at 0).
-  ///
-  /// ## Error
-  /// [`Error::InvalidPath`] if path is invalid or the path slice is empty.
-  /// [`Error::DataTypeMismatch`] if existing SD format is invalid.
-  /// [`Error::IndexOutofBounds`] if `element_index` is out of bounds.
-  pub fn conceal_array_entry(
-    &mut self,
-    path: &[&str],
-    element_index: usize,
-    salt: Option<String>,
-  ) -> Result<Disclosure> {
-    // Error if path is not provided.
-    if path.is_empty() {
-      return Err(Error::InvalidPath("the provided path length is 0".to_string()));
-    }
+        // Remove the value from the parent and create a disclosure for it.
+        let disclosure = Disclosure::new(
+          salt,
+          Some(element_key.to_owned()),
+          parent
+            .remove(&element_key)
+            .ok_or(Error::InvalidPath(format!("{} does not exist", element_key)))?,
+        );
 
-    // Determine salt.
-    let salt = salt.unwrap_or(Self::gen_rand(self.salt_size));
+        // Hash the disclosure.
+        let hash = self.hasher.encoded_digest(disclosure.as_str());
 
-    // Obtain the parent of the property specified by the provided path.
-    let (target_key, parent_value) = Self::get_target_property_and_its_parent(&mut self.object, path)?;
-
-    let array = parent_value
-      .get_mut(target_key)
-      .ok_or(Error::InvalidPath(format!("{} does not exist", target_key)))?
-      .as_array_mut()
-      .ok_or(Error::InvalidPath(format!("{} is not an array", target_key)))?;
-
-    // Get array element, calculate digest of the disclosure and replace the element with the object
-    // of form "{"...": "<digest>"}".
-    if let Some(element_value) = array.get_mut(element_index) {
-      let disclosure = Disclosure::new(salt, None, element_value.clone());
-      let hash = self.hasher.encoded_digest(disclosure.as_str());
-      let tripledot = json!({ARRAY_DIGEST_KEY: hash});
-      *element_value = tripledot;
-      Ok(disclosure)
-    } else {
-      Err(Error::IndexOutofBounds(element_index))
-    }
-  }
-
-  fn get_target_property_and_its_parent<'a, 'b>(
-    json: &'a mut Map<String, Value>,
-    path: &'b [&str],
-  ) -> Result<(&'b str, &'a mut Map<String, Value>)> {
-    let mut parent_value = json;
-    let mut target_property = path[0];
-    for index in 1..path.len() {
-      match parent_value
-        .get(target_property)
-        .ok_or(Error::InvalidPath(format!("{} does not exist", target_property)))?
-      {
-        Value::Object(_) => {
-          parent_value = parent_value
-            .get_mut(path[index - 1])
-            .ok_or(Error::InvalidPath(format!("{} does not exist", path[index - 1])))?
-            .as_object_mut()
-            .ok_or(Error::InvalidPath(format!("{} is not an object", path[index - 1])))?;
-          target_property = path[index];
-        }
-        _ => return Err(Error::InvalidPath(format!("{} is not an object", target_property))),
+        // Add the hash to the "_sd" array if exists; otherwise, create the array and insert the hash.
+        Self::add_digest_to_object(parent, hash)?;
+        Ok(disclosure)
       }
+      Value::Array(_) => {
+        let element = element_pointer.get_mut(&mut self.object).unwrap();
+        let disclosure = Disclosure::new(salt, None, element.clone());
+        let hash = self.hasher.encoded_digest(disclosure.as_str());
+        let tripledot = json!({ARRAY_DIGEST_KEY: hash});
+        *element = tripledot;
+        Ok(disclosure)
+      }
+      _ => Err(crate::Error::Unspecified(
+        "parent of element can can only be an object or an array".to_string(),
+      )),
     }
-    Ok((target_property, parent_value))
   }
 
   /// Adds the `_sd_alg` property to the top level of the object.
   /// The value is taken from the [`crate::Hasher::alg_name`] implementation.
   pub fn add_sd_alg_property(&mut self) -> Option<Value> {
-    self
-      .object
-      .insert(SD_ALG.to_string(), Value::String(self.hasher.alg_name().to_string()))
+    if let Some(object) = self.object.as_object_mut() {
+      object.insert(SD_ALG.to_string(), Value::String(self.hasher.alg_name().to_string()))
+    } else {
+      None // Should be unreachable since the `self.object` is checked to be an object on creation.
+    }
   }
 
   /// Returns the modified object as a string.
@@ -222,40 +169,35 @@ impl<H: Hasher> SdObjectEncoder<H> {
 
   /// Adds a decoy digest to the specified path.
   /// If path is an empty slice, decoys will be added to the top level.
-  pub fn add_decoys(&mut self, path: &[&str], number_of_decoys: usize) -> Result<()> {
+  pub fn add_decoys(&mut self, path: &str, number_of_decoys: usize) -> Result<()> {
     for _ in 0..number_of_decoys {
       self.add_decoy(path)?;
     }
     Ok(())
   }
 
-  fn add_decoy(&mut self, path: &[&str]) -> Result<Disclosure> {
-    if path.is_empty() {
+  fn add_decoy(&mut self, path: &str) -> Result<Disclosure> {
+    let mut element_pointer = path
+      .parse::<JsonPointer<_, _>>()
+      .map_err(|err| Error::InvalidPath(format!("{:?}", err)))?;
+
+    let value = element_pointer
+      .get_mut(&mut self.object)
+      .map_err(|err| Error::InvalidPath(format!("{:?}", err)))?;
+    if let Some(object) = value.as_object_mut() {
       let (disclosure, hash) = Self::random_digest(&self.hasher, self.salt_size, true);
-      Self::add_digest_to_object(&mut self.object, hash)?;
+      Self::add_digest_to_object(object, hash)?;
+      Ok(disclosure)
+    } else if let Some(array) = value.as_array_mut() {
+      let (disclosure, hash) = Self::random_digest(&self.hasher, self.salt_size, true);
+      let tripledot = json!({ARRAY_DIGEST_KEY: hash});
+      array.push(tripledot);
       Ok(disclosure)
     } else {
-      let (target_key, parent_value) = Self::get_target_property_and_its_parent(&mut self.object, path)?;
-
-      let value: &mut Value = parent_value
-        .get_mut(target_key)
-        .ok_or(Error::InvalidPath(format!("{} does not exist", target_key)))?;
-
-      if let Some(object) = value.as_object_mut() {
-        let (disclosure, hash) = Self::random_digest(&self.hasher, self.salt_size, true);
-        Self::add_digest_to_object(object, hash)?;
-        Ok(disclosure)
-      } else if let Some(array) = value.as_array_mut() {
-        let (disclosure, hash) = Self::random_digest(&self.hasher, self.salt_size, true);
-        let tripledot = json!({ARRAY_DIGEST_KEY: hash});
-        array.push(tripledot);
-        Ok(disclosure)
-      } else {
-        Err(Error::InvalidPath(format!(
-          "{} is neither an object nor an array",
-          target_key
-        )))
-      }
+      Err(Error::InvalidPath(format!(
+        "{:?} is neither an object nor an array",
+        element_pointer.pop()
+      )))
     }
   }
 
@@ -300,15 +242,15 @@ impl<H: Hasher> SdObjectEncoder<H> {
   }
 
   /// Returns a reference to the internal object.
-  pub fn object(&self) -> &Map<String, Value> {
+  pub fn object(&self) -> &Value {
     &self.object
   }
 
   /// Returns a mutable reference to the internal object.
-  #[cfg(test)]
-  pub(crate) fn object_mut(&mut self) -> &mut Map<String, Value> {
-    &mut self.object
-  }
+  // #[cfg(test)]
+  // pub(crate) fn object_mut(&mut self) -> &mut Map<String, Value> {
+  //   &mut self.value.as_object_mut()
+  // }
 
   /// Returns the used salt length.
   pub fn salt_size(&self) -> usize {
@@ -334,6 +276,7 @@ mod test {
 
   use super::SdObjectEncoder;
   use crate::Error;
+  use json_pointer::JsonPointer;
   use serde::Serialize;
   use serde_json::json;
   use serde_json::Value;
@@ -357,10 +300,10 @@ mod test {
   #[test]
   fn simple() {
     let mut encoder = SdObjectEncoder::try_from(object()).unwrap();
-    encoder.conceal(&["claim1", "abc"], None).unwrap();
-    encoder.conceal(&["id"], None).unwrap();
-    encoder.add_decoys(&[], 10).unwrap();
-    encoder.add_decoys(&["claim2"], 10).unwrap();
+    encoder.conceal("/claim1/abc", None).unwrap();
+    encoder.conceal("/id", None).unwrap();
+    encoder.add_decoys("/", 10).unwrap();
+    encoder.add_decoys("/claim2", 10).unwrap();
     assert!(encoder.object().get("id").is_none());
     assert_eq!(encoder.object.get("_sd").unwrap().as_array().unwrap().len(), 11);
     assert_eq!(encoder.object.get("claim2").unwrap().as_array().unwrap().len(), 12);
@@ -369,10 +312,10 @@ mod test {
   #[test]
   fn errors() {
     let mut encoder = SdObjectEncoder::try_from(object()).unwrap();
-    encoder.conceal(&["claim1", "abc"], None).unwrap();
+    encoder.conceal("/claim1/abc", None).unwrap();
     assert!(matches!(
-      encoder.conceal_array_entry(&["claim2"], 2, None).unwrap_err(),
-      Error::IndexOutofBounds(2)
+      encoder.conceal("claim2/2", None).unwrap_err(),
+      Error::InvalidPath(_)
     ));
   }
 
@@ -380,11 +323,11 @@ mod test {
   fn test_wrong_path() {
     let mut encoder = SdObjectEncoder::try_from(object()).unwrap();
     assert!(matches!(
-      encoder.conceal(&["claim12"], None).unwrap_err(),
+      encoder.conceal("/claim12", None).unwrap_err(),
       Error::InvalidPath(_)
     ));
     assert!(matches!(
-      encoder.conceal_array_entry(&["claim12"], 0, None).unwrap_err(),
+      encoder.conceal("/claim12/0", None).unwrap_err(),
       Error::InvalidPath(_)
     ));
   }
@@ -396,10 +339,10 @@ mod test {
       claim2: vec!["arr-value1".to_string(), "arr-vlaue2".to_string()],
     };
     let mut encoder = SdObjectEncoder::try_from_serializable(test_value).unwrap();
-    encoder.conceal(&["id"], None).unwrap();
-    encoder.add_decoys(&[], 10).unwrap();
-    encoder.add_decoys(&["claim2"], 10).unwrap();
-    assert!(encoder.object().get("id").is_none());
+    encoder.conceal("/id", None).unwrap();
+    encoder.add_decoys("/", 10).unwrap();
+    encoder.add_decoys("claim2", 10).unwrap();
+    assert!(encoder.object.get("id").is_none());
     assert_eq!(encoder.object.get("_sd").unwrap().as_array().unwrap().len(), 11);
     assert_eq!(encoder.object.get("claim2").unwrap().as_array().unwrap().len(), 12);
   }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -94,7 +94,7 @@ impl TryFrom<Value> for SdObjectEncoder {
 impl<H: Hasher> SdObjectEncoder<H> {
   /// Creates a new [`SdObjectEncoder`] with custom hash function to create digests.
   pub fn with_custom_hasher(object: &str, hasher: H) -> Result<Self> {
-    let object: Value = serde_json::to_value(&object).map_err(|e| Error::DeserializationError(e.to_string()))?;
+    let object: Value = serde_json::to_value(object).map_err(|e| Error::DeserializationError(e.to_string()))?;
     if !object.is_object() {
       return Err(Error::DataTypeMismatch("expected object".to_owned()));
     }
@@ -129,7 +129,7 @@ impl<H: Hasher> SdObjectEncoder<H> {
   /// encoder.conceal("/claim1/abc", None).unwrap(); //"abc": true
   /// encoder.conceal("/claim2/0", None).unwrap(); //conceals "val_1"
   /// ```
-  ///
+  /// 
   /// ## Error
   /// * [`Error::InvalidPath`] if pointer is invalid.
   /// * [`Error::DataTypeMismatch`] if existing SD format is invalid.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -148,7 +148,6 @@ impl<H: Hasher> SdObjectEncoder<H> {
 
     let parent = parent_pointer
       .get(&self.object)
-      // .map_err(|err| Error::InvalidPath("specified path does not match a json value".to_string()))?;
       .map_err(|err| Error::InvalidPath(format!("{:?}", err)))?;
 
     match parent {

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,9 +31,6 @@ pub enum Error {
   #[error("invalid input")]
   DeserializationError(String),
 
-  #[error("index {0} is out of bounds for the provided array")]
-  IndexOutofBounds(usize),
-
   #[error("{0}")]
   Unspecified(String),
 


### PR DESCRIPTION
Use [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) to conceal elements instead of string arrays, which enables users to conceal object elements located inside arrays and combines `conceal` and `conceal_array_entry` to only `conceal`. 

This PR also 
- fixes a bug when decoding nested object elements nested in arrays. 
- bumps version to 0.2.0.
- adds a changelog file.
- adds `HEADER_TYP` constant for convenience when creating JWT.


