### PR TITLE
Use encoded/decoded string when serializing / deserializing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ itertools = { version = "0.12", default-features = false, features = ["use_std"]
 iota-crypto = { version = "0.23", default-features = false, features = ["sha"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 json-pointer = "0.3.4"
+serde_with = "3.6.1"
 
 [dev-dependencies]
 josekit = "0.8.4"

--- a/src/sd_jwt.rs
+++ b/src/sd_jwt.rs
@@ -2,16 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Display;
+use std::str::FromStr;
 
 use crate::Error;
 use crate::Result;
 use itertools::Itertools;
-use serde::Deserialize;
-use serde::Serialize;
+use serde_with::DeserializeFromStr;
+use serde_with::SerializeDisplay;
 
 /// Representation of an SD-JWT of the format
 /// `<Issuer-signed JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>~<optional KB-JWT>`.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, SerializeDisplay, DeserializeFromStr)]
 pub struct SdJwt {
   /// The JWT part.
   pub jwt: String,
@@ -77,6 +78,13 @@ impl SdJwt {
 impl Display for SdJwt {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.write_str(&(self.presentation()))
+  }
+}
+
+impl FromStr for SdJwt {
+  type Err = Error;
+  fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    Self::parse(s)
   }
 }
 


### PR DESCRIPTION
# Description of change
Calling `serde::deserialize` should work the same as `SdJwt::parse` and `serde::serialize` should work as `SdJwt::presentation` but RN they just serialize or deserialize the inner structure of `SdJwt`. This PR fixes this behaviour.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
